### PR TITLE
Fix missing billingState

### DIFF
--- a/Allsecureexchange/Allsecureexchange/Model/Pay.php
+++ b/Allsecureexchange/Allsecureexchange/Model/Pay.php
@@ -570,7 +570,7 @@ class Pay extends \Magento\Payment\Model\Method\AbstractMethod
                 ->setBillingAddress1($street1)
                 ->setBillingCity($billingAddress->getCity())
                 ->setBillingPostcode($billingAddress->getPostcode())
-                ->setBillingState($billingAddress->getRegion() ? $billingAddress->getRegion() : $billingAddress->getCountryId())
+                ->setBillingState($billingAddress->getRegion() ? $billingAddress->getRegion() : $billingAddress->getCity())
                 ->setBillingCountry($billingAddress->getCountryId())
                 ->setBillingPhone($billingAddress->getTelephone())
                 ->setShippingFirstName($shippingAddress->getFirstname())

--- a/Allsecureexchange/Allsecureexchange/Model/Pay.php
+++ b/Allsecureexchange/Allsecureexchange/Model/Pay.php
@@ -570,7 +570,7 @@ class Pay extends \Magento\Payment\Model\Method\AbstractMethod
                 ->setBillingAddress1($street1)
                 ->setBillingCity($billingAddress->getCity())
                 ->setBillingPostcode($billingAddress->getPostcode())
-                ->setBillingState($billingAddress->getRegion())
+                ->setBillingState($billingAddress->getRegion() ? $billingAddress->getRegion() : $billingAddress->getCountryId())
                 ->setBillingCountry($billingAddress->getCountryId())
                 ->setBillingPhone($billingAddress->getTelephone())
                 ->setShippingFirstName($shippingAddress->getFirstname())

--- a/Allsecureexchange/Allsecureexchange/Model/PayAbstract.php
+++ b/Allsecureexchange/Allsecureexchange/Model/PayAbstract.php
@@ -528,7 +528,7 @@ class PayAbstract extends \Magento\Payment\Model\Method\AbstractMethod
                 ->setBillingAddress1($street1)
                 ->setBillingCity($billingAddress->getCity())
                 ->setBillingPostcode($billingAddress->getPostcode())
-                ->setBillingState($billingAddress->getRegion())
+                ->setBillingState($billingAddress->getRegion() ? $billingAddress->getRegion() : $billingAddress->getCountryId())
                 ->setBillingCountry($billingAddress->getCountryId())
                 ->setBillingPhone($billingAddress->getTelephone())
                 ->setShippingFirstName($shippingAddress->getFirstname())

--- a/Allsecureexchange/Allsecureexchange/Model/PayAbstract.php
+++ b/Allsecureexchange/Allsecureexchange/Model/PayAbstract.php
@@ -528,7 +528,7 @@ class PayAbstract extends \Magento\Payment\Model\Method\AbstractMethod
                 ->setBillingAddress1($street1)
                 ->setBillingCity($billingAddress->getCity())
                 ->setBillingPostcode($billingAddress->getPostcode())
-                ->setBillingState($billingAddress->getRegion() ? $billingAddress->getRegion() : $billingAddress->getCountryId())
+                ->setBillingState($billingAddress->getRegion() ? $billingAddress->getRegion() : $billingAddress->getCity())
                 ->setBillingCountry($billingAddress->getCountryId())
                 ->setBillingPhone($billingAddress->getTelephone())
                 ->setShippingFirstName($shippingAddress->getFirstname())


### PR DESCRIPTION
billingState is required by PSP.
Extension uses Magento address State/Region field for this,
but in some countries this field is not being used and is not required.
This PR solves the issue by using CountryId if Region is not populated.